### PR TITLE
Bugfix/add xrinteraction tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ git submodule add https://github.com/Fjordnet/UnityLIB-XRInteraction.git Assets/
 git submodule add https://github.com/Fjordnet/UnityLIB-Common.git Assets/Fjord/UnityLIB-Common
 ```
 
+2. Open project, and enable VR support in Edit menu > Project Settings > Player, XR Settings panel 'Virtual Reality Supported' checkbox. Remove 'Oculus' from the Virtual Reality SDKs list if it is auto-added.
+
+3. In Unity version 2018.3, OpenVR (Standalone) is now a package in the Unity Package Manager. Go to Window menu > Package Manager and install the 'Open VR (Standalone)' package.
+
+4. Re-open the project to ensure all dependencies are loaded.
+
 ###### Setting up a User.
 
 1. Drag the 'StandardUserRoot' prefab into your scene.

--- a/Scripts/Editor/InitializeXRInteractionEditor.cs
+++ b/Scripts/Editor/InitializeXRInteractionEditor.cs
@@ -4,60 +4,59 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
 
-[InitializeOnLoad]
-public class InitializeXRInteractionEditor : Editor
+namespace Fjord.XRInteraction
 {
-    static List<string> tagsToAdd = new List<string>
+    [InitializeOnLoad]
+    public class InitializeXRInteractionEditor : Editor
     {
-        "XRLaser",
-        "XRProximity",
-        "XRTeleport"
-    };
-
-    static InitializeXRInteractionEditor()
-    {
-        Debug.Log("Initializing XRInteraction library...");
-
-        UpdateTagList();
-
-        Debug.Log("XRInteraction library initialized.");
-    }
-
-    static void UpdateTagList()
-    {
-        SerializedObject tagManager = new SerializedObject(
-            AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")
-        );
-        SerializedProperty tagsProp = tagManager.FindProperty("tags");
-        
-        foreach (string tagText in tagsToAdd)
+        static List<string> tagsToAdd = new List<string>
         {
-            FindOrAddTag(tagsProp, tagText);
+            "XRLaser",
+            "XRProximity",
+            "XRTeleport"
+        };
+
+        static InitializeXRInteractionEditor()
+        {
+            UpdateTagList();
         }
-        tagManager.ApplyModifiedProperties();
-    }
 
-    static void FindOrAddTag(SerializedProperty tagsProp, string text)
-    {
-        bool foundTag = false;
-        for (int i=0; i < tagsProp.arraySize; i++)
+        static void UpdateTagList()
         {
-            SerializedProperty existingTag = tagsProp.GetArrayElementAtIndex(i);
-
-            // Already exists, exit
-            if (existingTag.stringValue.Equals(text))
+            SerializedObject tagManager = new SerializedObject(
+                AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")
+            );
+            SerializedProperty tagsProp = tagManager.FindProperty("tags");
+            
+            foreach (string tagText in tagsToAdd)
             {
-                foundTag = true;
-                break;
+                FindOrAddTag(tagsProp, tagText);
             }
+            tagManager.ApplyModifiedProperties();
         }
 
-        if (!foundTag)
+        static void FindOrAddTag(SerializedProperty tagsProp, string text)
         {
-            tagsProp.arraySize++;
-            SerializedProperty newTag = tagsProp.GetArrayElementAtIndex(tagsProp.arraySize-1);
-            newTag.stringValue = text;
-            Debug.LogFormat("XRInteraction Tags: Added tag {0} to project at index {1}.", text, tagsProp.arraySize);
+            bool foundTag = false;
+            for (int i=0; i < tagsProp.arraySize; i++)
+            {
+                SerializedProperty existingTag = tagsProp.GetArrayElementAtIndex(i);
+
+                // Already exists, exit
+                if (existingTag.stringValue.Equals(text))
+                {
+                    foundTag = true;
+                    break;
+                }
+            }
+
+            if (!foundTag)
+            {
+                tagsProp.arraySize++;
+                SerializedProperty newTag = tagsProp.GetArrayElementAtIndex(tagsProp.arraySize-1);
+                newTag.stringValue = text;
+                Debug.LogFormat("XRInteraction Tags: Added tag {0} to project at index {1}.", text, tagsProp.arraySize);
+            }
         }
     }
 }

--- a/Scripts/Editor/InitializeXRInteractionEditor.cs
+++ b/Scripts/Editor/InitializeXRInteractionEditor.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[InitializeOnLoad]
+public class InitializeXRInteractionEditor : Editor
+{
+    static List<string> tagsToAdd = new List<string>
+    {
+        "XRLaser",
+        "XRProximity",
+        "XRTeleport"
+    };
+
+    static InitializeXRInteractionEditor()
+    {
+        Debug.Log("Initializing XRInteraction library...");
+
+        UpdateTagList();
+
+        Debug.Log("XRInteraction library initialized.");
+    }
+
+    static void UpdateTagList()
+    {
+        SerializedObject tagManager = new SerializedObject(
+            AssetDatabase.LoadAllAssetsAtPath("ProjectSettings/TagManager.asset")
+        );
+        SerializedProperty tagsProp = tagManager.FindProperty("tags");
+        
+        foreach (string tagText in tagsToAdd)
+        {
+            FindOrAddTag(tagsProp, tagText);
+        }
+        tagManager.ApplyModifiedProperties();
+    }
+
+    static void FindOrAddTag(SerializedProperty tagsProp, string text)
+    {
+        bool foundTag = false;
+        for (int i=0; i < tagsProp.arraySize; i++)
+        {
+            SerializedProperty existingTag = tagsProp.GetArrayElementAtIndex(i);
+
+            // Already exists, exit
+            if (existingTag.stringValue.Equals(text))
+            {
+                foundTag = true;
+                break;
+            }
+        }
+
+        if (!foundTag)
+        {
+            tagsProp.arraySize++;
+            SerializedProperty newTag = tagsProp.GetArrayElementAtIndex(tagsProp.arraySize-1);
+            newTag.stringValue = text;
+            Debug.LogFormat("XRInteraction Tags: Added tag {0} to project at index {1}.", text, tagsProp.arraySize);
+        }
+    }
+}

--- a/Scripts/Editor/InitializeXRInteractionEditor.cs.meta
+++ b/Scripts/Editor/InitializeXRInteractionEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6968422d65cea034aa3298860993bd01
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added Scripts/Editor/InitializeXRInteractionEditor.cs script. Loads on editor load to perform any required initialization steps. For now, it only adds XRLaser, XRTeleport, and XRProximity tags if not present in the loaded project.

Also added some details to README about using the system in 2018.3, now that OpenVR is a package in Unity Package Manager. OpenVR (Standalone) package must be manually added for now in order to use XRInteraction.