### PR TITLE
fix: castShadows is deprecated in newer Unity versions

### DIFF
--- a/Scripts/Attachables/AttachableVisualizer.cs
+++ b/Scripts/Attachables/AttachableVisualizer.cs
@@ -60,7 +60,7 @@ namespace Fjord.XRInteraction.Attachables
                 GameObject lineRendererGame = new GameObject("LineRenderer" + i);
                 lineRendererGame.hideFlags = HideFlags.HideAndDontSave;
                 _lineRenderers[i] = lineRendererGame.AddComponent<LineRenderer>();
-                _lineRenderers[i].castShadows = false;
+                _lineRenderers[i].shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
                 _lineRenderers[i].receiveShadows = false;
                 _lineRenderers[i].colorGradient = _lineGradient.Gradient;
                 _lineRenderers[i].widthMultiplier = _lineWidth;


### PR DESCRIPTION
Unfortunately due to lack of specified Unity version it's hard to tell if you're even interested in this so-called fix. 
This is a small upgrade fix of the deprecated castShadows variable.