### PR TITLE
fix: userhead fade in/out issues

### DIFF
--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -47,6 +47,8 @@ namespace Fjord.XRInteraction.XRUser
         {
             if (ShouldFadeFromCollider(other))
             {
+                _headInColliders.RemoveAll(x => x == null); // If we've loaded a new scene and we were colliding in the previous, clear all empty colliders
+
                 _headInColliders.Add(other);
                 if (_headInColliders.Count == 1) _headUI.FadeOutView();
             }

--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -68,7 +68,8 @@ namespace Fjord.XRInteraction.XRUser
         /// </summary>
         private bool ShouldFadeFromCollider(Collider other)
         {
-            return ((_fadeOutOnEnterLayers & other.gameObject.layer) == other.gameObject.layer) &&
+            var layerConverted = 1 << other.gameObject.layer;
+            return ((_fadeOutOnEnterLayers & layerConverted) == layerConverted) &&
                    other.attachedRigidbody == null &&
                    !other.isTrigger;
         }


### PR DESCRIPTION
Two issues I noticed:
- LayerMask equality didn't work that way, collider's layer needs to be converted to power of 2 perhaps this is only case in the newer Unity versions
- When loading a new scene and the head is already colliding, script breaks because it keeps a reference to the now-empty collider. RemoveAll is a small dirty fix that handles this problem for me.