### PR TITLE
Fixed issue with XRUserHead fade layermask.

### DIFF
--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -68,7 +68,8 @@ namespace Fjord.XRInteraction.XRUser
         /// </summary>
         private bool ShouldFadeFromCollider(Collider other)
         {
-            return ((_fadeOutOnEnterLayers & other.gameObject.layer) == other.gameObject.layer) &&
+            int layerMask = 1 << other.gameObject.layer;
+            return ((_fadeOutOnEnterLayers & layerMask) == layerMask) &&
                    other.attachedRigidbody == null &&
                    !other.isTrigger;
         }


### PR DESCRIPTION
The trigger fade logic in XRUserHead was previously comparing the object's raw layer to the layermask. However because the Default layer has a value of 0 and an empty layermask is also 0, it was producing false positives when the layermask was set to Nothing. To address this, I have created a layermask out of the object's layer and compare that to the XRUserHead's layermask.