### PR TITLE
Fix/headfadelevelchange

### DIFF
--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -42,20 +42,14 @@ namespace Fjord.XRInteraction.XRUser
         {
             _headCamera = GetComponent<Camera>();
             _headUI = GetComponentInChildren<XRHeadUI>();
-            SceneManager.sceneUnloaded += SceneManagerOnSceneUnloaded;
         }
-
-        private void SceneManagerOnSceneUnloaded(Scene arg0)
-        {
-            _headInColliders.RemoveAll(x => x == null);
-            if (_headInColliders.Count == 0) _headUI.FadeInView();
-        }
-
+        
         private void OnTriggerEnter(Collider other)
         {
             if (ShouldFadeFromCollider(other))
             {
-                //should probably subscribe to the obects OnDestroy in some manner
+                //should probably subscribe to the objects OnDestroy in some manner
+                //OR switch to sphereoverlap every frame from head? 
                 _headInColliders.RemoveAll(x => x == null);
 
                 _headInColliders.Add(other);

--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -1,11 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.IO;
-using Fjord.Common.Extensions;
+﻿using System.Collections.Generic;
 using Fjord.XRInteraction.XRUI;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 namespace Fjord.XRInteraction.XRUser
 {

--- a/Scripts/XRUser/XRUserHead.cs
+++ b/Scripts/XRUser/XRUserHead.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Fjord.Common.Extensions;
 using Fjord.XRInteraction.XRUI;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 namespace Fjord.XRInteraction.XRUser
@@ -41,12 +42,22 @@ namespace Fjord.XRInteraction.XRUser
         {
             _headCamera = GetComponent<Camera>();
             _headUI = GetComponentInChildren<XRHeadUI>();
+            SceneManager.sceneUnloaded += SceneManagerOnSceneUnloaded;
+        }
+
+        private void SceneManagerOnSceneUnloaded(Scene arg0)
+        {
+            _headInColliders.RemoveAll(x => x == null);
+            if (_headInColliders.Count == 0) _headUI.FadeInView();
         }
 
         private void OnTriggerEnter(Collider other)
         {
             if (ShouldFadeFromCollider(other))
             {
+                //should probably subscribe to the obects OnDestroy in some manner
+                _headInColliders.RemoveAll(x => x == null);
+
                 _headInColliders.Add(other);
                 if (_headInColliders.Count == 1) _headUI.FadeOutView();
             }


### PR DESCRIPTION
Fixes issue of head being in colliders in a level that unloads. Some comments added to further discuss more ideal solution in the future.